### PR TITLE
drivers/dht: added support to use external pull-up

### DIFF
--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -84,7 +84,7 @@ static void dht_read_data(gpio_t dev, uint32_t *data, uint8_t *checksum)
     hwtimer_wait(HWTIMER_TICKS(40));
 
     /* sync on device */
-    gpio_init(dev, GPIO_DIR_IN, GPIO_PULLUP);
+    gpio_init(dev, GPIO_DIR_IN, DHT_PULLUP_MODE);
     while (!gpio_read(dev)) ;
     while (gpio_read(dev)) ;
 
@@ -123,7 +123,7 @@ static void dht_read_data(gpio_t dev, uint32_t *data, uint8_t *checksum)
     *checksum = les_bits & 0x00000000000000FF;
     *data = (les_bits >> 8) & 0x00000000FFFFFFFF;
 
-    gpio_init(dev, GPIO_DIR_OUT, GPIO_PULLUP);
+    gpio_init(dev, GPIO_DIR_OUT, DHT_PULLUP_MODE);
     gpio_set(dev);
 }
 
@@ -138,7 +138,7 @@ int dht_init(dht_t *dev, dht_type_t type, gpio_t gpio)
     dev->gpio = gpio;
     dev->type = type;
 
-    if (gpio_init(gpio, GPIO_DIR_OUT, GPIO_PULLUP) == -1) {
+    if (gpio_init(gpio, GPIO_DIR_OUT, DHT_PULLUP_MODE) == -1) {
         return -1;
     }
     gpio_set(gpio);

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -33,6 +33,12 @@
 extern "C" {
 #endif
 
+#ifndef DHT_EXT_PULLUP
+#define DHT_PULLUP_MODE GPIO_PULLUP
+#else
+#define DHT_PULLUP_MODE GPIO_NOPULL
+#endif
+
 /**
  * @brief data type for storing DHT sensor readings
  */


### PR DESCRIPTION
In DHT driver GPIO pin configured to use internal MCU's pullup only. Accordingly to GPIO driver implementation for STM32F1xx (see gpio_init function in cpu/stm32f1/periph/gpio.c) and MCU's reference manual (RM0008 rev.15 page 160), we can't use pullups when GPIO configured for output direction.
I decided to add DHT_EXT_PULLUP precompiler definition. If it defined, DHT driver will pass GPIO_NOPULL as the third (pullup) argument into the gpio_init function. And otherwise, if DHT_EXT_PULLUP is not defined, it will pass GPIO_PULLUP as it was implemented early.
And of couse, it is useful for cases when schematic developer decid to use external pullups instead of MCU's internal.